### PR TITLE
setup build process and serve static files

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+public

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,7 +7,11 @@ const PgPersistence = require("./db/pg");
 const MongoDB = require("./db/mongo");
 
 app.use(cors());
+app.use(express.static("public"));
 app.use(express.raw({ type: "*/*" }));
+app.get(["/web", "/web/:basketName"], (request, response) => {
+  response.redirect("/");
+});
 //Endpoints
 app.all("/:name", async (request, response) => {
   const name = request.params.name;

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "seed": "node scripts/seed.js",
     "seed:reset": "SEED_RESET=1 node scripts/seed.js",
     "seed:empty": "SEED_RESET=1 KEEP_EMPTY=1 node scripts/seed.js",
-    "smoke": "node scripts/mongo-smoke.js"
+    "smoke": "node scripts/mongo-smoke.js",
+    "build": "rm -r public; cd ../frontend && npm run build && cd ../backend && cp -r ../frontend/dist ./public"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
The entire app can now be run serving from a single port. Please note that the static files that get built have been ignored and you will have to build locally.

Build instructions:

- `cd backend`
- `npm run build`

This will rebuild the frontend and copy those files into the backend `public` folder.