### PR TITLE
Reformatted basket display page

### DIFF
--- a/frontend/src/components/BasketPage.jsx
+++ b/frontend/src/components/BasketPage.jsx
@@ -120,10 +120,10 @@ const BasketPage = () => {
   return (
     <div>
       <BasketHeader requestsCount={allRequests.length} />
-      <RequestBasket allRequests={allRequests} />
       <DeleteAllRequestsButton deleteRequests={handleDeleteRequest} />
       <DeleteBasketButton deleteBasket={handleDeleteBasket} />
       <Link to="/web">Click here to return to all baskets</Link>
+      <RequestBasket allRequests={allRequests} />
     </div>
   );
 };


### PR DESCRIPTION
Delete basket, delete requests, and home link are now displayed at the top of the page instead of coming after all headers / body of requests.