### PR TITLE
fix 404 conditions not terminating handler

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -19,6 +19,7 @@ app.all("/:name", async (request, response) => {
 
   if (!basket) {
     response.status(404).end();
+    return;
   }
 
   const rawBodyBuffer = request.body;
@@ -70,6 +71,7 @@ app.get("/api/baskets/:name", async (req, res) => {
 
   if (!basket) {
     res.status(404).end();
+    return;
   }
 
   // const requests = await PgPersistence.listRequests(basket.id);
@@ -92,6 +94,7 @@ app.delete("/api/baskets/:name/requests", async (request, response) => {
 
   if (!basket) {
     response.status(404).end();
+    return;
   }
 
   await MongoDB.deleteRequestsByBasketId(basket.id);
@@ -106,6 +109,7 @@ app.delete("/api/baskets/:name", async (request, response) => {
 
   if (!basket) {
     response.status(404).end();
+    return;
   }
 
   await MongoDB.deleteRequestsByBasketId(basket.id);


### PR DESCRIPTION
In routes where we checked if a basket exists, we were sending a 404 status but continued to execute the rest of the handler. This change returns early, after we set the 404 status.