### PR TITLE
make vite dev server proxy backend

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,10 @@ import react from "@vitejs/plugin-react";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      "/api": "http://localhost:3001",
+      "^/[a-zA-Z0-9]{7}": "http://localhost:3001",
+    },
+  },
 });


### PR DESCRIPTION
Issue: because the frontend expects the backend to be running on the same origin, running the vite dev server on port 5173 results in the frontend attempting to contact the backend on that port. The backend is listening on port 3001.

Solution: configure vite dev server to proxy requests to the API route and the endpoint route. Configure it to send those to port 3001.

Usage: you should once again be able to run the backend and frontend dev servers (`npm run dev`) side by side, to take advantage of the frontend dev server automatically refreshing on file changes.

Please note that the vite dev server will not allow traffic proxied through ngrok. This is possible to configure but, from what I could tell, would expose all your development files, so it seemed like bad practice.