### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ npm install
 Make sure both PostgreSQL and MongoDB are running.
 
 ```sh
-node seed.js
+npm run migrate
+npm run seed
 ```
 
 This will populate both databases with initial data.

--- a/README.md
+++ b/README.md
@@ -116,3 +116,27 @@ These should return a baskets table, a requests table, and a count of the docume
 
 - Ensure database connection details in `.env` are correct.
 - Check that both database services are running before seeding.
+
+## Building Frontend Static Files
+
+- **Frontend Only:**
+
+  If you just want to build the frontend static files _without_ copying them to the backend:
+
+  ```sh
+  cd frontend
+  npm run build
+  ```
+
+  This will build the files into `frontend/dist`.
+
+- **To Serve From Backend:**
+
+  If you want to serve the static files from the express backend, you can skip the instructions above and just do the following:
+
+  ```sh
+  cd backend
+  npm run build
+  ```
+
+  This will run the frontend build script and then copy the files into `backend/public`.


### PR DESCRIPTION
1. Reformatted without initially changing instructions
2. Added instructions for building frontend
3. Tweaked instructions for seeding databases

Previous instructions for seeding: `node seed.js`

I believe in order to use the proper configuration this needs to be started as `npm run seed`. I also added `npm run migrate` before that, since I believe that is required to create the sql tables.