### PR TITLE
update seed document schema

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -108,8 +108,8 @@ async function main() {
         if (hasBody) {
           const doc = {
             json_string: candidateBody,
-            size_bytes: Buffer.byteLength(candidateBody, "utf8"),
             created_at: new Date(),
+            basketName: basket.name,
           };
           const res = await bodies.insertOne(doc);
           bodyMongoId = res.insertedId.toString();


### PR DESCRIPTION
Brings `seed.js` back in line with the implicit document schema of `mongo.js`.

I am wondering if it should just import functions from `mongo.js` and `pg.js`, as discussed in #42 